### PR TITLE
Multiplying and dividing units

### DIFF
--- a/lib/alchemist.rb
+++ b/lib/alchemist.rb
@@ -480,11 +480,21 @@ module Alchemist
         end
       else
         if args[0] && args[0].is_a?(NumericConversion) && Alchemist.operator_actions[unit_name]
-          t1 = Conversions[ @unit_name ][0]
-          t2 = Conversions[ args[0].unit_name ][0]
+          first_unit_type = Conversions[ @unit_name ][0]
+          second_unit_type = Conversions[ args[0].unit_name ][0]
+
+          # In alchemist/compound.rb, find the right conversion where the units of the first
+          # item and the second item match. e.g. [:distance, :distance, :squared_meters]
           Alchemist.operator_actions[unit_name].each do |s1, s2, new_type|
-            if t1 == s1 && t2 == s2
-              return (@value * args[0].to_f).send(new_type)
+            if first_unit_type == s1 && second_unit_type == s2
+              first_unit_conversion_factor = 
+                Alchemist.conversion_table[first_unit_type][@unit_name]
+              second_unit_conversion_factor = 
+                Alchemist.conversion_table[second_unit_type][args.first.unit_name]
+                
+              first_value = @value / first_unit_conversion_factor
+              second_value = args[0].to_f * second_unit_conversion_factor
+              return ( eval( "#{first_value} #{unit_name.to_s} #{second_value}" ) ).send(new_type)
             end
           end
         end

--- a/test/alchemist_test.rb
+++ b/test/alchemist_test.rb
@@ -85,6 +85,10 @@ class AlchemistTest < Test::Unit::TestCase
     assert_equal(2.meters / 1.meters, 2.0)
   end
   
+  def test_square_meters_divided_by_centimeters
+    assert_equal( 100, (1.square_meter / 1.cm).to.meters.value )
+  end
+  
   def test_temperature
     assert_equal(1.fahrenheit, 1.fahrenheit)
     assert_in_delta(1.fahrenheit, 1.fahrenheit.to.fahrenheit, 1e-5)


### PR DESCRIPTION
*\* I merged this with the other branch I issued a pull request for. **

When multiplying or dividing units, this takes into account the operator being used (\* or /) and takes into account the exponent and factors of each unit.

Added test case:
- 1.square_meter / 1.centimeter should equal 100 but equals 0.01

*\* P.s. Thanks for creating this Gem, it's been hugely useful (and fun) to build off of. **
