### PR TITLE
raise custom error classes instead of Exception

### DIFF
--- a/lib/alchemist.rb
+++ b/lib/alchemist.rb
@@ -10,6 +10,9 @@ module Alchemist
 
   autoload :Earth, "alchemist/objects/planets/earth"
 
+  class IncompatibleType < StandardError ; end
+  class GeospatialArgumentError < StandardError ; end
+
   def self.setup category = nil
     if category
       load_category category

--- a/lib/alchemist/measurement.rb
+++ b/lib/alchemist/measurement.rb
@@ -132,7 +132,7 @@ module Alchemist
 
     def ensure_shared_type! measurement
       if !has_shared_types?(measurement.unprefixed_unit_name)
-        incompatible_types
+        incompatible_type_error
       end
     end
 
@@ -159,11 +159,7 @@ module Alchemist
           return Alchemist.measure(value * measurement.to_f, new_type)
         end
       end
-      incompatible_types
-    end
-
-    def incompatible_types
-      raise Exception, "Incompatible Types"
+      incompatible_type_error
     end
 
     def convertor
@@ -172,6 +168,12 @@ module Alchemist
 
     def precise_value
       BigDecimal.new(@value.to_s)
+    end
+
+    private
+
+    def incompatible_type_error
+      raise IncompatibleType, "Incompatible Types"
     end
   end
 end

--- a/lib/alchemist/measurement_convertor.rb
+++ b/lib/alchemist/measurement_convertor.rb
@@ -24,7 +24,7 @@ module Alchemist
       if parsed_unit.shares_type?(from)
         ConversionCalculator.new(from, parsed_unit).calculate
       else
-        raise Exception, "Incompatible Types"
+        raise IncompatibleType, "Incompatible Types"
       end
     end
   end

--- a/lib/alchemist/objects/planets/earth.rb
+++ b/lib/alchemist/objects/planets/earth.rb
@@ -12,7 +12,7 @@ module Alchemist
       elsif types.include?(:distance)
         geospatial_arc_to_angle
       else
-        raise Exception, "geospatial must either be angles or distance"
+        raise GeospatialArgumentError, "geospatial must either be angles or distance"
       end
     end
 


### PR DESCRIPTION
raise custom error classes instead of Exception so that if people want to rescue from Alchemist errors, they don't need to rescue from all exceptions