### PR TITLE
Fix test suite under newer versions of rspec

### DIFF
--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,13 +4,13 @@ module Alchemist
   describe Configuration do
     it "defaults use_si to false" do
       config = Configuration.new
-      expect(config.use_si?).to be_false
+      expect(config.use_si?).to be false
     end
 
     it "allows use_si to be changed" do
       config = Configuration.new
       config.use_si = true
-      expect(config.use_si?).to be_true
+      expect(config.use_si?).to be true
     end
   end
 end

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -36,12 +36,12 @@ module Alchemist
 
     it "knows if it has a measurement" do
       library = Library.new
-      expect(library.has_measurement?(:meter)).to be_true
+      expect(library.has_measurement?(:meter)).to be true
     end
 
     it "knows if it doesn't have a measurement" do
       library = Library.new
-      expect(library.has_measurement?(:wombat)).to be_false
+      expect(library.has_measurement?(:wombat)).to be false
     end
 
     def stub_loading


### PR DESCRIPTION
Newer versions of RSpec removed `be_true` and `be_false` in favor of
`be_truthy` or `be_falsey`. For these tests we can check strictly
against `true` or `false`.
