### PR TITLE
Refactor using Module subclass

### DIFF
--- a/lib/alchemist/library.rb
+++ b/lib/alchemist/library.rb
@@ -32,7 +32,7 @@ module Alchemist
     end
 
     def load_category(category)
-      @loaded_modules[category] = ModuleBuilder.new(category).build
+      @loaded_modules[category] = ModuleBuilder.new(category)
       Numeric.send :include, @loaded_modules[category]
     end
 

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -46,8 +46,7 @@ module Alchemist
 
     def stub_loading
       module_double = double(Module, define_unit_method: true)
-      module_builder_double = double(ModuleBuilder, build: module_double)
-      allow(ModuleBuilder).to receive(:new).and_return(module_builder_double)
+      allow(ModuleBuilder).to receive(:new).and_return(module_double)
       allow(Numeric).to receive(:send).with(:include, module_double).and_return(true)
     end
   end

--- a/spec/module_builder_spec.rb
+++ b/spec/module_builder_spec.rb
@@ -5,9 +5,8 @@ module Alchemist
     it "allows methods to be added to the build module" do
       allow(Alchemist).to receive(:library).and_return(library_double)
       builder = ModuleBuilder.new(:test)
-      test_module = builder.build
-      test_module.define_unit_method([:wombat])
-      expect(test_module.instance_methods).to include(:wombat)
+      builder.define_unit_method([:wombat])
+      expect(builder.instance_methods).to include(:wombat)
     end
 
     def library_double


### PR DESCRIPTION
The `ModuleBuilder` class can be simplified by just making it a subclass of
`Module`.

I don't know this library very well but all specs are passing for me with this change.

Ref: http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern