### PR TITLE
Update `BigDecimal` invocation syntax

### DIFF
--- a/lib/alchemist/conversion_calculator.rb
+++ b/lib/alchemist/conversion_calculator.rb
@@ -24,7 +24,7 @@ module Alchemist
       if proc_based?
         factor[1].call(base)
       else
-        base / BigDecimal.new(factor.to_s)
+        base / BigDecimal(factor.to_s)
       end
     end
 
@@ -33,7 +33,7 @@ module Alchemist
     end
 
     def base
-      @base ||= BigDecimal.new(from.base(type).to_s)
+      @base ||= BigDecimal(from.base(type).to_s)
     end
 
     def type

--- a/lib/alchemist/measurement.rb
+++ b/lib/alchemist/measurement.rb
@@ -167,7 +167,7 @@ module Alchemist
     end
 
     def precise_value
-      BigDecimal.new(@value.to_s)
+      BigDecimal(@value.to_s)
     end
 
     private


### PR DESCRIPTION
As of Ruby 2.6.0, `BigDecimal.new` is deprecated. We can adjust to the
officially-supported syntax without any side-effects.