### PR TITLE
Make Spaceship and comparison Numeric safe

### DIFF
--- a/lib/alchemist/measurement.rb
+++ b/lib/alchemist/measurement.rb
@@ -84,11 +84,13 @@ module Alchemist
     end
 
     def <=> other
-      to_f <=> other.to(unit_name).to_f
+      other = other.to(unit_name) unless other.is_a?(Numeric)
+      to_f <=> other.to_f
     end
 
     def == other
-      to_f <=> other.to(unit_name).to_f
+      other = other.to(unit_name) unless other.is_a?(Numeric)
+      to_f <=> other.to_f
     end
 
     def types


### PR DESCRIPTION
Rails 6.1 uses the spaceship operator against 0 to verify numerical-ness, but this doesn't work.